### PR TITLE
Circuit optimizations

### DIFF
--- a/examples/bitcoin.rs
+++ b/examples/bitcoin.rs
@@ -592,8 +592,8 @@ fn main() {
 
     println!("Making parameters");
     let start = Instant::now();
-    let params0: Params<Ec0> = Params::new(23);
-    let params1: Params<Ec1> = Params::new(23);
+    let params0: Params<Ec0> = Params::new(22);
+    let params1: Params<Ec1> = Params::new(22);
     println!("done, took {:?}", start.elapsed());
 
     let circuit = BitcoinHeaderCircuit;

--- a/examples/bitcoin.rs
+++ b/examples/bitcoin.rs
@@ -607,7 +607,7 @@ fn main() {
             CycleStep::A(old_proof) => {
                 println!("creating proof {}", height);
                 let start = Instant::now();
-                //assert!(halo::dev::recursive_is_satisfied::<_, _, _, halo::Basic>(&params1, &params0, old_proof.as_ref(), &circuit, &input).unwrap());
+                //assert_eq!(halo::dev::recursive_is_satisfied::<_, _, _, halo::Basic>(&params1, &params0, old_proof.as_ref(), &circuit, &input), Ok(true));
                 let proof = RecursiveProof::<Ec1, Ec0>::create_proof(
                     &params1,
                     &params0,
@@ -628,7 +628,7 @@ fn main() {
             CycleStep::B(old_proof) => {
                 println!("creating proof {}", height);
                 let start = Instant::now();
-                //assert!(halo::dev::recursive_is_satisfied::<_, _, _, halo::Basic>(&params0, &params1, old_proof.as_ref(), &circuit, &input).unwrap());
+                //assert_eq!(halo::dev::recursive_is_satisfied::<_, _, _, halo::Basic>(&params0, &params1, old_proof.as_ref(), &circuit, &input), Ok(true));
                 let proof = RecursiveProof::<Ec0, Ec1>::create_proof(
                     &params0,
                     &params1,

--- a/examples/bitcoin.rs
+++ b/examples/bitcoin.rs
@@ -607,6 +607,7 @@ fn main() {
             CycleStep::A(old_proof) => {
                 println!("creating proof {}", height);
                 let start = Instant::now();
+                //assert!(halo::dev::recursive_is_satisfied::<_, _, _, halo::Basic>(&params1, &params0, old_proof.as_ref(), &circuit, &input).unwrap());
                 let proof = RecursiveProof::<Ec1, Ec0>::create_proof(
                     &params1,
                     &params0,
@@ -627,6 +628,7 @@ fn main() {
             CycleStep::B(old_proof) => {
                 println!("creating proof {}", height);
                 let start = Instant::now();
+                //assert!(halo::dev::recursive_is_satisfied::<_, _, _, halo::Basic>(&params0, &params1, old_proof.as_ref(), &circuit, &input).unwrap());
                 let proof = RecursiveProof::<Ec0, Ec1>::create_proof(
                     &params0,
                     &params1,

--- a/src/curves/ec0.rs
+++ b/src/curves/ec0.rs
@@ -45,8 +45,8 @@ impl Curve for Ec0 {
     type Scalar = Fp;
     type Base = Fq;
 
-    const BETA_SCALAR: Self::Scalar = Fp::from_raw([0x33fffcfa00000002, 0xc37d383464024905, 0x96d4c09e11330dde, 0x5c5e464a35c12768]);
-    const BETA_BASE: Self::Base = Fq::from_raw([0xc0fffc3880000002, 0x230cec8b8a02aa85, 0x28cbb3fac2af2389, 0x5c5e464a35c12769]);
+    const BETA_SCALAR: Self::Scalar = Fp::BETA;
+    const BETA_BASE: Self::Base = Fq::BETA;
 
     fn b() -> Self::Base {
         B

--- a/src/curves/ec0.rs
+++ b/src/curves/ec0.rs
@@ -45,6 +45,9 @@ impl Curve for Ec0 {
     type Scalar = Fp;
     type Base = Fq;
 
+    const BETA_SCALAR: Self::Scalar = Fp::from_raw([0x33fffcfa00000002, 0xc37d383464024905, 0x96d4c09e11330dde, 0x5c5e464a35c12768]);
+    const BETA_BASE: Self::Base = Fq::from_raw([0xc0fffc3880000002, 0x230cec8b8a02aa85, 0x28cbb3fac2af2389, 0x5c5e464a35c12769]);
+
     fn b() -> Self::Base {
         B
     }
@@ -363,4 +366,12 @@ fn test_curve() {
     assert!(g * a != g * b);
 
     assert_eq!(g + Ec0::zero(), g - Ec0::zero());
+}
+
+#[test]
+fn test_endo() {
+    let g = Ec0::one();
+    let (x, y) = g.get_xy().unwrap();
+    let x = x * Ec0::BETA_BASE;
+    assert_eq!(g * Ec0::BETA_SCALAR, Ec0::from_xy_unchecked(x, y));
 }

--- a/src/curves/ec1.rs
+++ b/src/curves/ec1.rs
@@ -45,8 +45,8 @@ impl Curve for Ec1 {
     type Scalar = Fq;
     type Base = Fp;
 
-    const BETA_SCALAR: Self::Scalar = Fq::from_raw([0xc0fffc3880000002, 0x230cec8b8a02aa85, 0x28cbb3fac2af2389, 0x5c5e464a35c12769]);
-    const BETA_BASE: Self::Base = Fp::from_raw([0x33fffcfa00000002, 0xc37d383464024905, 0x96d4c09e11330dde, 0x5c5e464a35c12768]);
+    const BETA_SCALAR: Self::Scalar = Fq::BETA;
+    const BETA_BASE: Self::Base = Fp::BETA;
 
     fn b() -> Self::Base {
         B

--- a/src/curves/ec1.rs
+++ b/src/curves/ec1.rs
@@ -45,6 +45,9 @@ impl Curve for Ec1 {
     type Scalar = Fq;
     type Base = Fp;
 
+    const BETA_SCALAR: Self::Scalar = Fq::from_raw([0xc0fffc3880000002, 0x230cec8b8a02aa85, 0x28cbb3fac2af2389, 0x5c5e464a35c12769]);
+    const BETA_BASE: Self::Base = Fp::from_raw([0x33fffcfa00000002, 0xc37d383464024905, 0x96d4c09e11330dde, 0x5c5e464a35c12768]);
+
     fn b() -> Self::Base {
         B
     }
@@ -363,4 +366,12 @@ fn test_curve() {
     assert!(g * a != g * b);
 
     assert_eq!(g + Ec1::zero(), g - Ec1::zero());
+}
+
+#[test]
+fn test_endo() {
+    let g = Ec1::one();
+    let (x, y) = g.get_xy().unwrap();
+    let x = x * Ec1::BETA_BASE;
+    assert_eq!(g * Ec1::BETA_SCALAR, Ec1::from_xy_unchecked(x, y));
 }

--- a/src/curves/mod.rs
+++ b/src/curves/mod.rs
@@ -33,6 +33,9 @@ pub trait Curve:
     type Scalar: Field;
     type Base: Field;
 
+    const BETA_SCALAR: Self::Scalar;
+    const BETA_BASE: Self::Base;
+
     fn zero() -> Self;
     fn one() -> Self;
 

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -306,16 +306,17 @@ where
     E1: Curve<Base = <E2 as Curve>::Scalar>,
     E2: Curve<Base = <E1 as Curve>::Scalar>,
 {
-    let (newdeferred, new_leftovers, old_leftovers) = match old_proof {
+    let (newdeferred, new_leftovers, old_leftovers, forkvalues) = match old_proof {
         Some(old_proof) => {
-            let (_, newdeferred, l1, l2) = old_proof.verify_inner(e2params, e1params, circuit)?;
+            let (_, newdeferred, l1, l2, forkvalues) = old_proof.verify_inner(e2params, e1params, circuit)?;
 
-            (newdeferred, l1, l2)
+            (newdeferred, l1, l2, forkvalues)
         }
         None => (
             Deferred::dummy(e2params.k),
             Leftovers::dummy(e2params),
             Leftovers::dummy(e1params),
+            vec![0; e2params.k]
         ),
     };
 
@@ -326,6 +327,7 @@ where
         proof: None,
         inner_circuit: circuit,
         new_payload,
+        forkvalues: Some(&forkvalues[..]),
         old_leftovers: Some(old_leftovers.clone()),
         new_leftovers: Some(new_leftovers.clone()),
         deferred: Some(newdeferred.clone()),

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -308,7 +308,8 @@ where
 {
     let (newdeferred, new_leftovers, old_leftovers, forkvalues) = match old_proof {
         Some(old_proof) => {
-            let (_, newdeferred, l1, l2, forkvalues) = old_proof.verify_inner(e2params, e1params, circuit)?;
+            let (_, newdeferred, l1, l2, forkvalues) =
+                old_proof.verify_inner(e2params, e1params, circuit)?;
 
             (newdeferred, l1, l2, forkvalues)
         }
@@ -316,7 +317,7 @@ where
             Deferred::dummy(e2params.k),
             Leftovers::dummy(e2params),
             Leftovers::dummy(e1params),
-            vec![0; e2params.k]
+            vec![0; e2params.k],
         ),
     };
 

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -745,6 +745,7 @@ where
         proof: None,
         inner_circuit: circuit,
         new_payload,
+        forkvalues: None,
         old_leftovers: None,
         new_leftovers: None,
         deferred: None,

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -411,6 +411,12 @@ impl Field for Fp {
         0x700e6467ac19ef1d,
         0x376bc3c62040b13f,
     ];
+    const BETA: Self = Fp::from_raw([
+        0x33fffcfa00000002,
+        0xc37d383464024905,
+        0x96d4c09e11330dde,
+        0x5c5e464a35c12768,
+    ]);
 
     fn is_zero(&self) -> Choice {
         self.ct_eq(&Self::zero())

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -411,6 +411,12 @@ impl Field for Fq {
         0x4ab442efc8114a13,
         0x24f282841580762a,
     ];
+    const BETA: Self = Fq::from_raw([
+        0xc0fffc3880000002,
+        0x230cec8b8a02aa85,
+        0x28cbb3fac2af2389,
+        0x5c5e464a35c12769,
+    ]);
 
     fn is_zero(&self) -> Choice {
         self.ct_eq(&Self::zero())

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -48,6 +48,9 @@ pub trait Field:
     /// RESCUE_INVALPHA * RESCUE_ALPHA = 1 mod (p - 1)
     const RESCUE_INVALPHA: [u64; 4];
 
+    /// Element of multiplicative order 3.
+    const BETA: Self;
+
     fn is_zero(&self) -> Choice;
 
     fn from_u64(v: u64) -> Self;

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -1571,7 +1571,7 @@ impl<C: Curve> CurvePoint<C> {
     ) -> Result<Self, SynthesisError> {
         // TODO
         let p = self.get_point();
-        
+
         Self::witness(cs, || {
             let p = p.ok_or(SynthesisError::AssignmentMissing)?;
             let p = p.unwrap_or(C::zero());
@@ -1597,7 +1597,7 @@ impl<C: Curve> CurvePoint<C> {
     ) -> Result<Self, SynthesisError> {
         // TODO
         let p = self.get_point();
-        
+
         Self::witness(cs, || {
             let p = p.ok_or(SynthesisError::AssignmentMissing)?;
             let p = p.unwrap_or(C::zero());

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -163,9 +163,6 @@ impl<C: Curve> CurvePoint<C> {
             .y
             .value()
             .and_then(|y| condition.get_value().map(|b| if b { -y } else { y }));
-        let y_ret = AllocatedNum::alloc(cs.namespace(|| "y_ret"), || {
-            y_ret_val.ok_or(SynthesisError::AssignmentMissing)
-        })?;
 
         // y_self × (1 - 2.bit) = y_ret
         let (y_self_var, negator, y_ret_var) = cs.multiply(
@@ -189,7 +186,8 @@ impl<C: Curve> CurvePoint<C> {
                 - &condition.lc(CS::ONE, Coeff::Full(C::Base::from_u64(2)))
                 - negator,
         );
-        cs.enforce_zero(y_ret.lc() - y_ret_var);
+
+        let y_ret = AllocatedNum::from_raw_unchecked(y_ret_val, y_ret_var);
 
         Ok(CurvePoint {
             x: self.x,

--- a/src/gadgets/num.rs
+++ b/src/gadgets/num.rs
@@ -77,6 +77,16 @@ pub struct AllocatedNum<F: Field> {
 }
 
 impl<F: Field> AllocatedNum<F> {
+    pub fn one<CS>(cs: CS) -> AllocatedNum<F>
+    where
+        CS: ConstraintSystem<F>,
+    {
+        AllocatedNum {
+            value: Some(F::one()),
+            var: CS::ONE,
+        }
+    }
+
     pub fn alloc<CS, FF>(mut cs: CS, value: FF) -> Result<Self, SynthesisError>
     where
         CS: ConstraintSystem<F>,
@@ -148,6 +158,10 @@ impl<F: Field> AllocatedNum<F> {
             value: product,
             var: o,
         })
+    }
+
+    pub fn from_raw_unchecked(value: Option<F>, var: Variable) -> Self {
+        AllocatedNum { value, var }
     }
 
     pub fn alloc_and_square<FF, CS>(mut cs: CS, value: FF) -> Result<(Self, Self), SynthesisError>
@@ -308,6 +322,19 @@ impl<F: Field> AllocatedNum<F> {
     }
 }
 
+use crate::gadgets::AllocatedBit;
+
+impl<F: Field> From<AllocatedBit> for AllocatedNum<F> {
+    fn from(bit: AllocatedBit) -> AllocatedNum<F> {
+        AllocatedNum {
+            var: bit.get_variable(),
+            value: bit
+                .get_value()
+                .map(|v| if v { F::one() } else { F::zero() }),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum Num<F: Field> {
     Constant(Coeff<F>),
@@ -347,6 +374,13 @@ impl<F: Field> From<(Coeff<F>, Num<F>)> for Num<F> {
 }
 
 impl<F: Field> Num<F> {
+    pub fn scale(self, val: F) -> Self {
+        match self {
+            Num::Constant(coeff) => Num::Constant(coeff * val),
+            Num::Allocated(coeff, var) => Num::Allocated(coeff * val, var),
+        }
+    }
+
     pub fn constant(val: F) -> Self {
         Num::Constant(Coeff::from(val))
     }
@@ -508,6 +542,13 @@ impl<F: Field> Add<(Coeff<F>, Num<F>)> for Combination<F> {
 }
 
 impl<F: Field> Combination<F> {
+    pub fn scale(self, by: F) -> Self {
+        let value = self.value.map(|v| v * by);
+        let terms = self.terms.into_iter().map(|t| t.scale(by)).collect();
+
+        Combination { value, terms }
+    }
+
     pub fn get_value(&self) -> Option<F> {
         self.value
     }

--- a/src/gadgets/num.rs
+++ b/src/gadgets/num.rs
@@ -279,10 +279,7 @@ impl<F: Field> AllocatedNum<F> {
     {
         let mut newval = None;
         let newnum = AllocatedNum::alloc(cs.namespace(|| "sqrt"), || {
-            let sqrt = self
-                .value
-                .ok_or(SynthesisError::AssignmentMissing)?
-                .sqrt();
+            let sqrt = self.value.ok_or(SynthesisError::AssignmentMissing)?.sqrt();
             if bool::from(sqrt.is_some()) {
                 let tmp = sqrt.unwrap();
                 newval = Some(tmp);

--- a/src/gadgets/num.rs
+++ b/src/gadgets/num.rs
@@ -542,6 +542,13 @@ impl<F: Field> Add<(Coeff<F>, Num<F>)> for Combination<F> {
 }
 
 impl<F: Field> Combination<F> {
+    pub fn zero() -> Self {
+        Combination {
+            value: Some(F::zero()),
+            terms: vec![]
+        }
+    }
+
     pub fn scale(self, by: F) -> Self {
         let value = self.value.map(|v| v * by);
         let terms = self.terms.into_iter().map(|t| t.scale(by)).collect();

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -29,8 +29,7 @@ impl<C: Curve> Leftovers<C> {
                 ret.extend(C::Base::zero().to_bytes()[..].iter().cloned());
             }
         }
-        // TODO: This is 128-bit
-        ret.extend(self.y_new.to_bytes()[..].iter().cloned());
+        ret.extend(self.y_new.to_bytes()[..].iter().cloned().take(16));
         {
             let xy = self.g_new.get_xy();
 
@@ -44,7 +43,7 @@ impl<C: Curve> Leftovers<C> {
             }
         }
         for challenge in &self.challenges_sq_new {
-            ret.extend(challenge.to_bytes()[..].iter().cloned());
+            ret.extend(challenge.to_bytes()[..].iter().cloned().take(16));
         }
 
         ret
@@ -87,9 +86,8 @@ impl<C: Curve> Leftovers<C> {
     }
 }
 
-/*
-(16 + 2k) F
-*/
+// 4 * 128 + 6 * 256 + k * 128 + 256 + k * 128 + 5 * 256
+// = 12 * 256 + (4 + 2k) * 128
 #[derive(Clone)]
 pub struct Deferred<F: Field> {
     // comes from circuit
@@ -126,11 +124,10 @@ impl<F: Field> Deferred<F> {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut ret = vec![];
 
-        // TODO: they're 128-bit
-        ret.extend(self.x.to_bytes()[..].iter().cloned());
-        ret.extend(self.y_old.to_bytes()[..].iter().cloned());
-        ret.extend(self.y_cur.to_bytes()[..].iter().cloned());
-        ret.extend(self.y_new.to_bytes()[..].iter().cloned());
+        ret.extend(self.x.to_bytes()[..].iter().cloned().take(16));
+        ret.extend(self.y_old.to_bytes()[..].iter().cloned().take(16));
+        ret.extend(self.y_cur.to_bytes()[..].iter().cloned().take(16));
+        ret.extend(self.y_new.to_bytes()[..].iter().cloned().take(16));
 
         ret.extend(self.ky_opening.to_bytes()[..].iter().cloned());
         ret.extend(self.tx_positive_opening.to_bytes()[..].iter().cloned());
@@ -139,11 +136,11 @@ impl<F: Field> Deferred<F> {
         ret.extend(self.rx_opening.to_bytes()[..].iter().cloned());
         ret.extend(self.rxy_opening.to_bytes()[..].iter().cloned());
         for a in &self.challenges_sq_old {
-            ret.extend(a.to_bytes()[..].iter().cloned());
+            ret.extend(a.to_bytes()[..].iter().cloned().take(16));
         }
         ret.extend(self.gx_old_opening.to_bytes()[..].iter().cloned());
         for a in &self.challenges_sq_new {
-            ret.extend(a.to_bytes()[..].iter().cloned());
+            ret.extend(a.to_bytes()[..].iter().cloned().take(16));
         }
         ret.extend(self.b_x.to_bytes()[..].iter().cloned());
         ret.extend(self.b_xy.to_bytes()[..].iter().cloned());

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -183,7 +183,6 @@ impl<F: Field> Deferred<F> {
             .collect();
         let mut challenges_inv = challenges.clone();
         F::batch_invert(&mut challenges_inv);
-        let gx_old_opening = compute_b(F::one(), &challenges, &challenges_inv);
         let b_one = compute_b(F::one(), &challenges, &challenges_inv);
 
         Deferred {
@@ -198,7 +197,7 @@ impl<F: Field> Deferred<F> {
             rx_opening: F::zero(),
             rxy_opening: F::zero(),
             challenges_sq_packed_old: challenges_sq_packed.clone(),
-            gx_old_opening,
+            gx_old_opening: b_one,
             challenges_sq_packed_new: challenges_sq_packed.clone(),
             b_x: b_one,
             b_xy: b_one,

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -1,6 +1,9 @@
 use crate::rescue::Rescue;
 use crate::*;
 
+/// Packed challenge that happens to end up being valid on both curves
+const MAGIC: u64 = 7;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Leftovers<C: Curve> {
     // comes from circuit
@@ -10,7 +13,7 @@ pub struct Leftovers<C: Curve> {
     // comes from circuit
     pub g_new: C,
     // comes from circuit
-    pub challenges_sq_new: Vec<C::Scalar>,
+    pub challenges_sq_packed_new: Vec<C::Scalar>,
 }
 
 impl<C: Curve> Leftovers<C> {
@@ -42,7 +45,7 @@ impl<C: Curve> Leftovers<C> {
                 ret.extend(C::Base::zero().to_bytes()[..].iter().cloned());
             }
         }
-        for challenge in &self.challenges_sq_new {
+        for challenge in &self.challenges_sq_packed_new {
             ret.extend(challenge.to_bytes()[..].iter().cloned().take(16));
         }
 
@@ -54,15 +57,25 @@ impl<C: Curve> Leftovers<C> {
     pub fn dummy(params: &Params<C>) -> Leftovers<C> {
         let y_new = C::Scalar::zero();
         let s_new_commitment = C::zero();
-        let challenges_sq_new = vec![C::Scalar::one(); params.k];
-        let g_new =
-            compute_g_for_inner_product(&params.generators, &challenges_sq_new, C::Scalar::one());
+        let challenges_sq_packed_new = vec![C::Scalar::from_u64(MAGIC); params.k];
+        let challenges_sq_new: Vec<C::Scalar> = challenges_sq_packed_new
+            .iter()
+            .map(|v| get_challenge_scalar(*v))
+            .collect();
+        let challenges_new: Vec<C::Scalar> = challenges_sq_new
+            .iter()
+            .map(|v| v.sqrt().unwrap())
+            .collect(); // TODO: DUMMY IN OTHER FUNCTION
+        let mut challenges_inv_new = challenges_new;
+        let allinv = Field::batch_invert(&mut challenges_inv_new);
+
+        let g_new = compute_g_for_inner_product(&params.generators, &challenges_sq_new, allinv);
 
         Leftovers {
             s_new_commitment,
             y_new,
             g_new,
-            challenges_sq_new,
+            challenges_sq_packed_new,
         }
     }
 
@@ -74,13 +87,20 @@ impl<C: Curve> Leftovers<C> {
     ) -> Result<bool, SynthesisError> {
         let sx = params.compute_sx::<_, S>(circuit, self.y_new)?;
         let s_new_commitment = params.commit(&sx, false);
-        assert_eq!(self.challenges_sq_new.len(), params.k);
+        assert_eq!(self.challenges_sq_packed_new.len(), params.k);
+
+        let challenges_sq_new: Vec<C::Scalar> = self
+            .challenges_sq_packed_new
+            .iter()
+            .map(|v| get_challenge_scalar(*v))
+            .collect();
+
         let mut allinv = C::Scalar::one();
-        for c in &self.challenges_sq_new {
+        for c in &challenges_sq_new {
             allinv = allinv * &(c.sqrt().unwrap()); // TODO
         }
         allinv = allinv.invert().unwrap();
-        let g_new = compute_g_for_inner_product(&params.generators, &self.challenges_sq_new, allinv);
+        let g_new = compute_g_for_inner_product(&params.generators, &challenges_sq_new, allinv);
 
         Ok((g_new == self.g_new) && (s_new_commitment == self.s_new_commitment))
     }
@@ -107,11 +127,11 @@ pub struct Deferred<F: Field> {
     pub rxy_opening: F,
 
     // enforces to equal old leftovers
-    pub challenges_sq_old: Vec<F>,
+    pub challenges_sq_packed_old: Vec<F>,
     // fed to circuit
     pub gx_old_opening: F,
     // comes from circuit
-    pub challenges_sq_new: Vec<F>,
+    pub challenges_sq_packed_new: Vec<F>,
     // fed to circuit
     pub b_x: F,
     pub b_xy: F,
@@ -135,11 +155,11 @@ impl<F: Field> Deferred<F> {
         ret.extend(self.sx_cur_opening.to_bytes()[..].iter().cloned());
         ret.extend(self.rx_opening.to_bytes()[..].iter().cloned());
         ret.extend(self.rxy_opening.to_bytes()[..].iter().cloned());
-        for a in &self.challenges_sq_old {
+        for a in &self.challenges_sq_packed_old {
             ret.extend(a.to_bytes()[..].iter().cloned().take(16));
         }
         ret.extend(self.gx_old_opening.to_bytes()[..].iter().cloned());
-        for a in &self.challenges_sq_new {
+        for a in &self.challenges_sq_packed_new {
             ret.extend(a.to_bytes()[..].iter().cloned().take(16));
         }
         ret.extend(self.b_x.to_bytes()[..].iter().cloned());
@@ -152,9 +172,19 @@ impl<F: Field> Deferred<F> {
     }
 
     pub fn dummy(k: usize) -> Self {
-        let challenges = vec![F::one(); k];
-        let gx_old_opening = compute_b(F::one(), &challenges, &challenges);
-        let b_one = compute_b(F::one(), &challenges, &challenges);
+        let challenges_sq_packed = vec![F::from_u64(MAGIC); k];
+        let challenges_sq_new: Vec<F> = challenges_sq_packed
+            .iter()
+            .map(|v| get_challenge_scalar(*v))
+            .collect();
+        let challenges: Vec<F> = challenges_sq_new
+            .iter()
+            .map(|v| v.sqrt().unwrap())
+            .collect();
+        let mut challenges_inv = challenges.clone();
+        F::batch_invert(&mut challenges_inv);
+        let gx_old_opening = compute_b(F::one(), &challenges, &challenges_inv);
+        let b_one = compute_b(F::one(), &challenges, &challenges_inv);
 
         Deferred {
             x: F::one(),
@@ -167,9 +197,9 @@ impl<F: Field> Deferred<F> {
             sx_cur_opening: F::zero(),
             rx_opening: F::zero(),
             rxy_opening: F::zero(),
-            challenges_sq_old: challenges.clone(),
+            challenges_sq_packed_old: challenges_sq_packed.clone(),
             gx_old_opening,
-            challenges_sq_new: challenges.clone(),
+            challenges_sq_packed_new: challenges_sq_packed.clone(),
             b_x: b_one,
             b_xy: b_one,
             b_y_old: b_one,
@@ -238,7 +268,13 @@ impl<F: Field> Deferred<F> {
         let (lhs, rhs) = self.compute(k);
 
         let correct_gx_old_opening = {
-            let mut challenges = self.challenges_sq_old.clone();
+            let challenges_sq_old: Vec<F> = self
+                .challenges_sq_packed_old
+                .iter()
+                .map(|v| get_challenge_scalar(*v))
+                .collect();
+
+            let mut challenges = challenges_sq_old.clone();
             for a in &mut challenges {
                 *a = a.sqrt().unwrap(); // TODO
             }
@@ -249,7 +285,13 @@ impl<F: Field> Deferred<F> {
         };
 
         // TODO: prover could have put a zero here
-        let mut challenges = self.challenges_sq_new.clone();
+        let challenges_sq_new: Vec<F> = self
+            .challenges_sq_packed_new
+            .iter()
+            .map(|v| get_challenge_scalar(*v))
+            .collect();
+
+        let mut challenges = challenges_sq_new.clone();
         for a in &mut challenges {
             *a = a.sqrt().unwrap(); // TODO
         }
@@ -429,14 +471,19 @@ impl<C: Curve> Proof<C> {
         let s_old_commitment = old_leftovers.s_new_commitment;
 
         // Compute the coefficients for G_old
-        let challenges_old: Vec<C::Scalar> = old_leftovers
-            .challenges_sq_new
+        let challenges_sq_old: Vec<C::Scalar> = old_leftovers
+            .challenges_sq_packed_new
+            .iter()
+            .map(|v| get_challenge_scalar(*v))
+            .collect();
+
+        let challenges_old: Vec<C::Scalar> = challenges_sq_old
             .iter()
             .map(|a| a.sqrt().unwrap())
             .collect();
         let mut challenges_old_inv = challenges_old.clone();
         let allinv_old = Field::batch_invert(&mut challenges_old_inv);
-        let gx_old = compute_g_coeffs_for_inner_product(&old_leftovers.challenges_sq_new, allinv_old);
+        let gx_old = compute_g_coeffs_for_inner_product(&challenges_sq_old, allinv_old);
 
         // Get G_old
         let g_old_commitment = old_leftovers.g_new;
@@ -651,7 +698,7 @@ impl<C: Curve> Proof<C> {
         }
 
         let mut transcript = transcript;
-        let (inner_product, challenges_sq_new, g_new) = MultiPolynomialOpening::new_proof(
+        let (inner_product, challenges_sq_packed_new, g_new) = MultiPolynomialOpening::new_proof(
             &mut transcript,
             &[
                 (
@@ -708,7 +755,7 @@ impl<C: Curve> Proof<C> {
             s_new_commitment,
             y_new,
             g_new,
-            challenges_sq_new,
+            challenges_sq_packed_new,
         };
 
         Ok((
@@ -822,7 +869,13 @@ impl<C: Curve> Proof<C> {
         append_scalar::<C>(&mut transcript, &self.tx_negative_opening);
         append_scalar::<C>(&mut transcript, &self.sx_new_opening);
 
-        let mut challenges_old = leftovers.challenges_sq_new.clone();
+        let challenges_sq_old: Vec<C::Scalar> = leftovers
+            .challenges_sq_packed_new
+            .iter()
+            .map(|v| get_challenge_scalar(*v))
+            .collect();
+
+        let mut challenges_old = challenges_sq_old.clone();
         for c in &mut challenges_old {
             *c = c.sqrt().unwrap(); // TODO
         }
@@ -855,49 +908,55 @@ impl<C: Curve> Proof<C> {
         let qy_opening = self.sx_cur_opening + &(ky_opening * &z);
 
         let mut transcript = transcript;
-        let (inner_product_satisfied, challenges_sq_new, g_new, forkvalues) = self.inner_product.verify_proof(
-            &mut transcript,
-            &[
-                PolynomialOpening {
-                    commitment: p_commitment,
-                    opening: p_opening,
-                    point: x,
-                    right_edge: false,
-                },
-                PolynomialOpening {
-                    commitment: self.r_commitment,
-                    opening: self.rxy_opening,
-                    point: x * &y_cur,
-                    right_edge: true,
-                },
-                PolynomialOpening {
-                    commitment: self.c_commitment,
-                    opening: self.sx_old_opening,
-                    point: leftovers.y_new,
-                    right_edge: false,
-                },
-                PolynomialOpening {
-                    commitment: q_commitment,
-                    opening: qy_opening,
-                    point: y_cur,
-                    right_edge: false,
-                },
-                PolynomialOpening {
-                    commitment: self.c_commitment,
-                    opening: self.sx_new_opening,
-                    point: y_new,
-                    right_edge: false,
-                },
-            ],
-            params.k,
-        );
+        let (inner_product_satisfied, challenges_sq_packed_new, g_new, forkvalues) =
+            self.inner_product.verify_proof(
+                &mut transcript,
+                &[
+                    PolynomialOpening {
+                        commitment: p_commitment,
+                        opening: p_opening,
+                        point: x,
+                        right_edge: false,
+                    },
+                    PolynomialOpening {
+                        commitment: self.r_commitment,
+                        opening: self.rxy_opening,
+                        point: x * &y_cur,
+                        right_edge: true,
+                    },
+                    PolynomialOpening {
+                        commitment: self.c_commitment,
+                        opening: self.sx_old_opening,
+                        point: leftovers.y_new,
+                        right_edge: false,
+                    },
+                    PolynomialOpening {
+                        commitment: q_commitment,
+                        opening: qy_opening,
+                        point: y_cur,
+                        right_edge: false,
+                    },
+                    PolynomialOpening {
+                        commitment: self.c_commitment,
+                        opening: self.sx_new_opening,
+                        point: y_new,
+                        right_edge: false,
+                    },
+                ],
+                params.k,
+            );
 
         let metadata = Leftovers {
             s_new_commitment: self.s_new_commitment,
             y_new,
             g_new,
-            challenges_sq_new: challenges_sq_new.clone(),
+            challenges_sq_packed_new: challenges_sq_packed_new.clone(),
         };
+
+        let mut challenges_sq_new = challenges_sq_packed_new.clone();
+        for c in &mut challenges_sq_new {
+            *c = get_challenge_scalar(*c);
+        }
 
         let mut challenges_new = challenges_sq_new.clone();
         for c in &mut challenges_new {
@@ -920,9 +979,9 @@ impl<C: Curve> Proof<C> {
             sx_cur_opening: self.sx_cur_opening,
             rx_opening: self.rx_opening,
             rxy_opening: self.rxy_opening,
-            challenges_sq_old: leftovers.challenges_sq_new.clone(),
+            challenges_sq_packed_old: leftovers.challenges_sq_packed_new.clone(),
             gx_old_opening,
-            challenges_sq_new: challenges_sq_new.clone(),
+            challenges_sq_packed_new: challenges_sq_packed_new.clone(),
             b_x: compute_b(x, &challenges_new, &challenges_new_inv),
             b_xy: compute_b(x * &y_cur, &challenges_new, &challenges_new_inv),
             b_y_old: compute_b(leftovers.y_new, &challenges_new, &challenges_new_inv),
@@ -1234,7 +1293,7 @@ impl<C: Curve> MultiPolynomialOpening<C> {
 
         let mut challenges = vec![];
         let mut challenges_inv = vec![];
-        let mut challenges_sq = vec![];
+        let mut challenges_sq_packed = vec![];
         let mut forkvalues = vec![];
         assert_eq!(self.rounds.len(), k);
 
@@ -1247,14 +1306,15 @@ impl<C: Curve> MultiPolynomialOpening<C> {
             }
             let mut forkvalue = C::Base::zero();
             let mut forkvalue_u8 = 0;
-            let (challenge, challenge_sq) = loop {
+            let (challenge, challenge_sq, challenge_sq_packed) = loop {
                 let mut transcript = transcript.clone();
                 transcript.absorb(forkvalue);
-                let challenge_sq = get_challenge::<_, C::Scalar>(&mut transcript);
+                let challenge_sq_packed = get_challenge::<_, C::Scalar>(&mut transcript);
+                let challenge_sq: C::Scalar = get_challenge_scalar(challenge_sq_packed);
                 match challenge_sq.sqrt().to_option() {
                     Some(challenge) => {
-                        break (challenge, challenge_sq);
-                    },
+                        break (challenge, challenge_sq, challenge_sq_packed);
+                    }
                     None => {
                         forkvalue = forkvalue + &C::Base::one();
                         forkvalue_u8 += 1;
@@ -1263,13 +1323,16 @@ impl<C: Curve> MultiPolynomialOpening<C> {
             };
             forkvalues.push(forkvalue_u8);
             transcript.absorb(forkvalue);
-            assert_eq!(get_challenge::<_, C::Scalar>(transcript), challenge_sq);
+            assert_eq!(
+                get_challenge::<_, C::Scalar>(transcript),
+                challenge_sq_packed
+            );
             let challenge_inv = challenge.invert().unwrap();
             let challenge_inv_sq = challenge_inv.square();
 
             challenges.push(challenge);
             challenges_inv.push(challenge_inv);
-            challenges_sq.push(challenge_sq);
+            challenges_sq_packed.push(challenge_sq_packed);
 
             for j in 0..instances.len() {
                 p[j] = p[j] + (round.L[j] * challenge_sq);
@@ -1283,15 +1346,15 @@ impl<C: Curve> MultiPolynomialOpening<C> {
             let b = compute_b(instances[j].point, &challenges, &challenges_inv);
 
             if p[j] != (self.g * self.a[j]) {
-                return (false, challenges_sq, self.g, forkvalues);
+                return (false, challenges_sq_packed, self.g, forkvalues);
             }
 
             if v[j] != (self.a[j] * &b) {
-                return (false, challenges_sq, self.g, forkvalues);
+                return (false, challenges_sq_packed, self.g, forkvalues);
             }
         }
 
-        return (true, challenges_sq, self.g, forkvalues);
+        return (true, challenges_sq_packed, self.g, forkvalues);
     }
 
     pub fn new_proof<'a>(
@@ -1324,7 +1387,7 @@ impl<C: Curve> MultiPolynomialOpening<C> {
             b.push(v);
         }
 
-        let mut challenges_sq = vec![];
+        let mut challenges_sq_packed = vec![];
         {
             let mut k = k;
             #[allow(non_snake_case)]
@@ -1350,24 +1413,28 @@ impl<C: Curve> MultiPolynomialOpening<C> {
                     round_r.push(this_r);
                 }
                 let mut forkvalue = C::Base::zero();
-                let (challenge, challenge_sq) = loop {
+                let (challenge, challenge_sq, challenge_sq_packed) = loop {
                     let mut transcript = transcript.clone();
                     transcript.absorb(forkvalue);
-                    let challenge_sq = get_challenge::<_, C::Scalar>(&mut transcript);
+                    let challenge_sq_packed = get_challenge::<_, C::Scalar>(&mut transcript);
+                    let challenge_sq: C::Scalar = get_challenge_scalar(challenge_sq_packed);
                     match challenge_sq.sqrt().to_option() {
                         Some(challenge) => {
-                            break (challenge, challenge_sq);
-                        },
+                            break (challenge, challenge_sq, challenge_sq_packed);
+                        }
                         None => {
                             forkvalue = forkvalue + &C::Base::one();
                         }
                     }
                 };
                 transcript.absorb(forkvalue);
-                assert_eq!(get_challenge::<_, C::Scalar>(transcript), challenge_sq);
+                assert_eq!(
+                    get_challenge::<_, C::Scalar>(transcript),
+                    challenge_sq_packed
+                );
                 let challenge_inv = challenge.invert().unwrap();
 
-                challenges_sq.push(challenge_sq);
+                challenges_sq_packed.push(challenge_sq_packed);
 
                 for j in 0..instances.len() {
                     for i in 0..l {
@@ -1407,7 +1474,7 @@ impl<C: Curve> MultiPolynomialOpening<C> {
                 a: final_a,
                 g: generators[0],
             },
-            challenges_sq,
+            challenges_sq_packed,
             generators[0],
         )
     }
@@ -1433,7 +1500,7 @@ fn get_challenge<F1: Field, F2: Field>(transcript: &mut Rescue<F1>) -> F2 {
     let challenge = transcript.squeeze();
     let challenge = challenge.get_lower_128();
 
-    let challenge = challenge | (1u128 << 127);
+    let challenge = challenge | (1 << 127);
 
     F2::from_u128(challenge)
 }

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -2,7 +2,7 @@ use crate::rescue::Rescue;
 use crate::*;
 
 /// Packed challenge that happens to end up being valid on both curves
-const MAGIC: u64 = 7;
+const MAGIC: u64 = 12;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Leftovers<C: Curve> {

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -635,7 +635,8 @@ impl<C: Curve> Proof<C> {
 
         // Obtain the challenge z
 
-        let z = get_challenge::<_, C::Scalar>(&mut transcript);
+        let mut z = get_challenge::<_, C::Scalar>(&mut transcript);
+        z = get_challenge_scalar(z);
 
         // Compute P, the commitment to p(x), and p, the value it
         // must open to
@@ -884,7 +885,8 @@ impl<C: Curve> Proof<C> {
         let gx_old_opening = compute_b(x, &challenges_old, &challenges_old_inv);
         append_scalar::<C>(&mut transcript, &gx_old_opening);
 
-        let z = get_challenge::<_, C::Scalar>(&mut transcript);
+        let mut z = get_challenge::<_, C::Scalar>(&mut transcript);
+        z = get_challenge_scalar(z);
         //println!("VERIFIER: z in the verifier: {:?}", z);
 
         let p_commitment = self.r_commitment;

--- a/src/recursion.rs
+++ b/src/recursion.rs
@@ -930,26 +930,26 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
             let p_commitment = p_commitment * &z + leftovers.g_new;
             */
             let p_commitment = r_commitment.clone();
-            let p_commitment = p_commitment.multiply_fast(cs.namespace(|| "mul z 1"), &z)?;
+            let p_commitment = p_commitment.multiply_endo(cs.namespace(|| "mul z 1"), &z)?;
             let p_commitment =
                 p_commitment.add(cs.namespace(|| "add s_old_commitment"), &s_old_commitment)?;
-            let p_commitment = p_commitment.multiply_fast(cs.namespace(|| "mul z 2"), &z)?;
+            let p_commitment = p_commitment.multiply_endo(cs.namespace(|| "mul z 2"), &z)?;
             let p_commitment =
                 p_commitment.add(cs.namespace(|| "add s_cur_commitment"), &s_cur_commitment)?;
-            let p_commitment = p_commitment.multiply_fast(cs.namespace(|| "mul z 3"), &z)?;
+            let p_commitment = p_commitment.multiply_endo(cs.namespace(|| "mul z 3"), &z)?;
             let p_commitment = p_commitment.add(
                 cs.namespace(|| "add t_positive_commitment"),
                 &t_positive_commitment,
             )?;
-            let p_commitment = p_commitment.multiply_fast(cs.namespace(|| "mul z 4"), &z)?;
+            let p_commitment = p_commitment.multiply_endo(cs.namespace(|| "mul z 4"), &z)?;
             let p_commitment = p_commitment.add(
                 cs.namespace(|| "add t_negative_commitment"),
                 &t_negative_commitment,
             )?;
-            let p_commitment = p_commitment.multiply_fast(cs.namespace(|| "mul z 5"), &z)?;
+            let p_commitment = p_commitment.multiply_endo(cs.namespace(|| "mul z 5"), &z)?;
             let p_commitment =
                 p_commitment.add(cs.namespace(|| "add s_new_commitment"), &s_new_commitment)?;
-            let p_commitment = p_commitment.multiply_fast(cs.namespace(|| "mul z 6"), &z)?;
+            let p_commitment = p_commitment.multiply_endo(cs.namespace(|| "mul z 6"), &z)?;
             p_commitment.add(cs.namespace(|| "add g_old"), &g_old)?
         };
 
@@ -965,26 +965,26 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
             let p_opening = p_opening * &z + &gx_old_opening;
             */
             let p_opening = rx_opening_pt;
-            let p_opening = p_opening.multiply_fast(cs.namespace(|| "mul z 1"), &z)?;
+            let p_opening = p_opening.multiply_endo(cs.namespace(|| "mul z 1"), &z)?;
             let p_opening =
                 p_opening.add(cs.namespace(|| "add sx_old_opening_pt"), &sx_old_opening_pt)?;
-            let p_opening = p_opening.multiply_fast(cs.namespace(|| "mul z 2"), &z)?;
+            let p_opening = p_opening.multiply_endo(cs.namespace(|| "mul z 2"), &z)?;
             let p_opening =
                 p_opening.add(cs.namespace(|| "add sx_cur_opening_pt"), &sx_cur_opening_pt)?;
-            let p_opening = p_opening.multiply_fast(cs.namespace(|| "mul z 3"), &z)?;
+            let p_opening = p_opening.multiply_endo(cs.namespace(|| "mul z 3"), &z)?;
             let p_opening = p_opening.add(
                 cs.namespace(|| "add tx_positive_opening_pt"),
                 &tx_positive_opening_pt,
             )?;
-            let p_opening = p_opening.multiply_fast(cs.namespace(|| "mul z 4"), &z)?;
+            let p_opening = p_opening.multiply_endo(cs.namespace(|| "mul z 4"), &z)?;
             let p_opening = p_opening.add(
                 cs.namespace(|| "add tx_negative_opening_pt"),
                 &tx_negative_opening_pt,
             )?;
-            let p_opening = p_opening.multiply_fast(cs.namespace(|| "mul z 5"), &z)?;
+            let p_opening = p_opening.multiply_endo(cs.namespace(|| "mul z 5"), &z)?;
             let p_opening =
                 p_opening.add(cs.namespace(|| "add sx_new_opening_pt"), &sx_new_opening_pt)?;
-            let p_opening = p_opening.multiply_fast(cs.namespace(|| "mul z 6"), &z)?;
+            let p_opening = p_opening.multiply_endo(cs.namespace(|| "mul z 6"), &z)?;
             p_opening.add(cs.namespace(|| "add gx_old_opening_pt"), &gx_old_opening_pt)?
         };
 
@@ -995,13 +995,13 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
             let qy_opening = self.sx_cur_opening + &(ky_opening * &z);
             */
 
-            let q_commitment = k_commitment.multiply_fast(cs.namespace(|| "mul z 1"), &z)?;
+            let q_commitment = k_commitment.multiply_endo(cs.namespace(|| "mul z 1"), &z)?;
             q_commitment.add(cs.namespace(|| "add c_commitment"), &c_commitment)?
         };
 
         let qy_opening = {
             let mut cs = cs.namespace(|| "qy_opening");
-            let qy_opening = ky_opening_pt.multiply_fast(cs.namespace(|| "mul z 2"), &z)?;
+            let qy_opening = ky_opening_pt.multiply_endo(cs.namespace(|| "mul z 2"), &z)?;
             qy_opening.add(cs.namespace(|| "add sx_cur_opening_pt"), &sx_cur_opening_pt)?
         };
 

--- a/src/recursion.rs
+++ b/src/recursion.rs
@@ -233,17 +233,17 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
         b_y_new: F,
         */
 
-        let x = self.obtain_scalar_from_bits(cs.namespace(|| "pack x"), &deferred[0..256])?;
-        deferred = &deferred[256..];
+        let x = self.obtain_scalar_from_bits(cs.namespace(|| "pack x"), &deferred[0..128])?;
+        deferred = &deferred[128..];
         let y_old =
-            self.obtain_scalar_from_bits(cs.namespace(|| "pack y_old"), &deferred[0..256])?;
-        deferred = &deferred[256..];
+            self.obtain_scalar_from_bits(cs.namespace(|| "pack y_old"), &deferred[0..128])?;
+        deferred = &deferred[128..];
         let y_cur =
-            self.obtain_scalar_from_bits(cs.namespace(|| "pack y_cur"), &deferred[0..256])?;
-        deferred = &deferred[256..];
+            self.obtain_scalar_from_bits(cs.namespace(|| "pack y_cur"), &deferred[0..128])?;
+        deferred = &deferred[128..];
         let y_new =
-            self.obtain_scalar_from_bits(cs.namespace(|| "pack y_new"), &deferred[0..256])?;
-        deferred = &deferred[256..];
+            self.obtain_scalar_from_bits(cs.namespace(|| "pack y_new"), &deferred[0..128])?;
+        deferred = &deferred[128..];
         let ky_opening =
             self.obtain_scalar_from_bits(cs.namespace(|| "pack ky_opening"), &deferred[0..256])?;
         deferred = &deferred[256..];
@@ -270,9 +270,9 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
         for i in 0..self.params.k {
             challenges_sq_old.push(self.obtain_scalar_from_bits(
                 cs.namespace(|| format!("pack old challenge {}", i)),
-                &deferred[0..256],
+                &deferred[0..128],
             )?);
-            deferred = &deferred[256..];
+            deferred = &deferred[128..];
         }
         let gx_old_opening = self
             .obtain_scalar_from_bits(cs.namespace(|| "pack gx_old_opening"), &deferred[0..256])?;
@@ -281,9 +281,9 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
         for i in 0..self.params.k {
             challenges_sq_new.push(self.obtain_scalar_from_bits(
                 cs.namespace(|| format!("pack new challenge {}", i)),
-                &deferred[0..256],
+                &deferred[0..128],
             )?);
-            deferred = &deferred[256..];
+            deferred = &deferred[128..];
         }
         let b_x = self.obtain_scalar_from_bits(cs.namespace(|| "pack b_x"), &deferred[0..256])?;
         deferred = &deferred[256..];
@@ -616,8 +616,6 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
         mut cs: CS,
         bits: &[AllocatedBit],
     ) -> Result<AllocatedNum<E1::Scalar>, SynthesisError> {
-        assert_eq!(bits.len(), 256);
-
         let mut value = Some(E1::Scalar::zero());
         let mut cur = E1::Scalar::one();
         let mut lc = LinearCombination::zero();
@@ -778,7 +776,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let ky_opening_pt = g.multiply(
             cs.namespace(|| "ky_opening_pt"),
-            &new_deferred[256 * 4..256 * 5],
+            &new_deferred[128 * 4..128 * 4 + 256],
         )?;
         self.commit_point(
             cs.namespace(|| "commit ky_opening_pt"),
@@ -788,7 +786,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let rx_opening_pt = g.multiply(
             cs.namespace(|| "rx_opening_pt"),
-            &new_deferred[256 * 8..256 * 9],
+            &new_deferred[128 * 4 + 256 * 4..128 * 4 + 256 * 4 + 256],
         )?;
         self.commit_point(
             cs.namespace(|| "commit rx_opening_pt"),
@@ -798,7 +796,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let rxy_opening_pt = g.multiply(
             cs.namespace(|| "rxy_opening_pt"),
-            &new_deferred[256 * 9..256 * 10],
+            &new_deferred[128 * 4 + 256 * 5..128 * 4 + 256 * 5 + 256],
         )?;
         self.commit_point(
             cs.namespace(|| "commit rxy_opening_pt"),
@@ -821,7 +819,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let sx_cur_opening_pt = g.multiply(
             cs.namespace(|| "sx_cur_opening_pt"),
-            &new_deferred[256 * 7..256 * 8],
+            &new_deferred[128 * 4 + 256 * 3..128 * 4 + 256 * 3 + 256],
         )?;
         self.commit_point(
             cs.namespace(|| "commit sx_cur_opening_pt"),
@@ -831,7 +829,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let tx_positive_opening_pt = g.multiply(
             cs.namespace(|| "tx_positive_opening_pt"),
-            &new_deferred[256 * 5..256 * 6],
+            &new_deferred[128 * 4 + 256 * 1..128 * 4 + 256 * 1 + 256],
         )?;
         self.commit_point(
             cs.namespace(|| "commit tx_positive_opening_pt"),
@@ -841,7 +839,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let tx_negative_opening_pt = g.multiply(
             cs.namespace(|| "tx_negative_opening_pt"),
-            &new_deferred[256 * 6..256 * 7],
+            &new_deferred[128 * 4 + 256 * 2..128 * 4 + 256 * 2 + 256],
         )?;
         self.commit_point(
             cs.namespace(|| "commit tx_negative_opening_pt"),
@@ -864,7 +862,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
 
         let gx_old_opening_pt = g.multiply(
             cs.namespace(|| "gx_old_opening_pt"),
-            &new_deferred[256 * (10 + self.params.k)..256 * (11 + self.params.k)],
+            &new_deferred[256 * 6 + (4 + self.params.k) * 128..256 * 7 + (4 + self.params.k) * 128],
         )?;
         self.commit_point(
             cs.namespace(|| "commit gx_old_opening_pt"),
@@ -916,13 +914,13 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 cs.namespace(|| "x"),
                 base_case.clone(),
                 &x,
-                &old_leftovers[256 * 3..256 * 4],
+                &old_leftovers[256 * 2 + 128..256 * 3 + 128],
             )?;
             self.equal_unless_base_case(
                 cs.namespace(|| "y"),
                 base_case.clone(),
                 &y,
-                &old_leftovers[256 * 4..256 * 5],
+                &old_leftovers[256 * 3 + 128..256 * 4 + 128],
             )?;
         }
 
@@ -1013,12 +1011,13 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
             qy_opening.add(cs.namespace(|| "add sx_cur_opening_pt"), &sx_cur_opening_pt)?
         };
 
+        // 7 * 256 + (4 + 2k) * 128
         let b = &[
-            &new_deferred[256 * (11 + 2 * self.params.k)..256 * (11 + 2 * self.params.k) + 256],
-            &new_deferred[256 * (12 + 2 * self.params.k)..256 * (12 + 2 * self.params.k) + 256],
-            &new_deferred[256 * (13 + 2 * self.params.k)..256 * (13 + 2 * self.params.k) + 256],
-            &new_deferred[256 * (14 + 2 * self.params.k)..256 * (14 + 2 * self.params.k) + 256],
-            &new_deferred[256 * (15 + 2 * self.params.k)..256 * (15 + 2 * self.params.k) + 256],
+            &new_deferred[256 * 7 + (4 + 2 * self.params.k) * 128..256 * 7 + (4 + 2 * self.params.k) * 128 + 256],
+            &new_deferred[256 * 8 + (4 + 2 * self.params.k) * 128..256 * 8 + (4 + 2 * self.params.k) * 128 + 256],
+            &new_deferred[256 * 9 + (4 + 2 * self.params.k) * 128..256 * 9 + (4 + 2 * self.params.k) * 128 + 256],
+            &new_deferred[256 * 10 + (4 + 2 * self.params.k) * 128..256 * 10 + (4 + 2 * self.params.k) * 128 + 256],
+            &new_deferred[256 * 11 + (4 + 2 * self.params.k) * 128..256 * 11 + (4 + 2 * self.params.k) * 128 + 256],
         ];
 
         let (g_new, challenges_sq_new) = self.verify_inner_product(
@@ -1069,11 +1068,6 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 &y_new,
                 &new_leftovers[512..512 + 128],
             )?;
-            for i in 0..128 {
-                cs.enforce_zero(LinearCombination::from(
-                    new_leftovers[512 + 128 + i].get_variable(),
-                ));
-            }
         }
 
         {
@@ -1085,13 +1079,13 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 cs.namespace(|| "x"),
                 base_case.clone(),
                 &x,
-                &new_leftovers[256 * 3..256 * 4],
+                &new_leftovers[256 * 2 + 128..256 * 3 + 128],
             )?;
             self.equal_unless_base_case(
                 cs.namespace(|| "y"),
                 base_case.clone(),
                 &y,
-                &new_leftovers[256 * 4..256 * 5],
+                &new_leftovers[256 * 3 + 128..256 * 4 + 128],
             )?;
         }
 
@@ -1100,27 +1094,17 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 cs.namespace(|| format!("challenge {} in new_leftovers", i)),
                 base_case.clone(),
                 &challenge_sq,
-                &new_leftovers[256 * 5 + 256 * i..256 * 5 + 256 * i + 128],
+                &new_leftovers[256 * 4 + 128 + 128 * i..256 * 4 + 128 + 128 * i + 128],
             )?;
-            for j in 0..128 {
-                cs.enforce_zero(LinearCombination::from(
-                    new_leftovers[256 * 5 + 256 * i + 128 + j].get_variable(),
-                ));
-            }
 
-            // k + 11 is the start on deferred for the new challenges
+            // 4 * 128 + 6 * 256 + k * 128 + 256 is the start
             self.equal_unless_base_case(
                 cs.namespace(|| format!("challenge {} in new_deferred", i)),
                 base_case.clone(),
                 &challenge_sq,
-                &new_deferred[256 * (11 + self.params.k) + i * 256
-                    ..256 * (11 + self.params.k) + i * 256 + 128],
+                &new_deferred[(4 * 128 + 6 * 256 + self.params.k * 128 + 256) + i * 128
+                    ..(4 * 128 + 6 * 256 + self.params.k * 128 + 256) + i * 128 + 128],
             )?;
-            for j in 0..128 {
-                cs.enforce_zero(LinearCombination::from(
-                    new_deferred[256 * (11 + self.params.k) + i * 256 + 128 + j].get_variable(),
-                ));
-            }
         }
 
         // x (deferred)
@@ -1131,11 +1115,6 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 &x,
                 &new_deferred[0..128],
             )?;
-            for i in 0..128 {
-                cs.enforce_zero(LinearCombination::from(
-                    new_deferred[128 + i].get_variable(),
-                ));
-            }
         }
 
         // y_cur (deferred)
@@ -1144,13 +1123,8 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 cs.namespace(|| "challenge y_cur in new_deferred"),
                 base_case.clone(),
                 &y_cur,
-                &new_deferred[256 * 2..256 * 2 + 128],
+                &new_deferred[128 * 2..128 * 2 + 128],
             )?;
-            for i in 0..128 {
-                cs.enforce_zero(LinearCombination::from(
-                    new_deferred[256 * 2 + 128 + i].get_variable(),
-                ));
-            }
         }
 
         // y_new (deferred)
@@ -1159,13 +1133,8 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                 cs.namespace(|| "challenge y_new in new_deferred"),
                 base_case.clone(),
                 &y_new,
-                &new_deferred[256 * 3..256 * 3 + 128],
+                &new_deferred[128 * 3..128 * 3 + 128],
             )?;
-            for i in 0..128 {
-                cs.enforce_zero(LinearCombination::from(
-                    new_deferred[256 * 3 + 128 + i].get_variable(),
-                ));
-            }
         }
 
         Ok(())
@@ -1371,8 +1340,9 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                     }
                 }
             } else {
-                // 256 * (5 + k)
-                let num_bits = 256 * (5 + self.params.k);
+                // (256 * 2) + 128 + (256 * 2) + (128 * k)
+                // = 256 * 4 + 128 * (k + 1)
+                let num_bits = 256 * 4 + 128 * (self.params.k + 1);
                 for i in 0..num_bits {
                     leftovers1.push(AllocatedBit::alloc_input_unchecked(
                         cs.namespace(|| format!("bit {}", i)),
@@ -1397,8 +1367,9 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                     }
                 }
             } else {
-                // 256 * (5 + k)
-                let num_bits = 256 * (5 + self.params.k);
+                // (256 * 2) + 128 + (256 * 2) + (128 * k)
+                // = 256 * 4 + 128 * (k + 1)
+                let num_bits = 256 * 4 + 128 * (self.params.k + 1);
                 for i in 0..num_bits {
                     leftovers2.push(AllocatedBit::alloc_input_unchecked(
                         cs.namespace(|| format!("bit {}", i)),
@@ -1423,11 +1394,11 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                     }
                 }
             } else {
-                // 256 * (16 + 2k)
-                let num_bits = 256 * (16 + 2 * self.params.k);
+                // 12 * 256 + (4 + 2k) * 128
+                let num_bits = 12 * 256 + (4 + 2 * self.params.k) * 128;
                 for i in 0..num_bits {
                     deferred.push(AllocatedBit::alloc_input_unchecked(
-                        cs.namespace(|| format!("bit {}", i)),
+                        cs.namespace(|| format!("deferred bit {}", i)),
                         || Ok(false),
                     )?);
                 }
@@ -1548,8 +1519,9 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                     }
                 }
             } else {
-                // 256 * (5 + k)
-                let num_bits = 256 * (5 + self.params.k);
+                // (256 * 2) + 128 + (256 * 2) + (128 * k)
+                // = 256 * 4 + 128 * (k + 1)
+                let num_bits = 256 * 4 + 128 * (self.params.k + 1);
                 for i in 0..num_bits {
                     old_leftovers1.push(AllocatedBit::alloc(
                         cs.namespace(|| format!("bit {}", i)),
@@ -1589,6 +1561,8 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
             }
         }
 
+        assert_eq!(old_deferred.len(), deferred.len());
+
         let mut bits_for_k_commitment = vec![];
         bits_for_k_commitment.extend(old_payload.clone());
         bits_for_k_commitment.extend(old_leftovers1.clone());
@@ -1627,16 +1601,16 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
         self.equal_unless_base_case(
             cs.namespace(|| "deferred[challeges] == old_leftovers1[challenges]"),
             base_case.clone(),
-            &deferred[256 * 10..256 * (10 + self.params.k)],
-            &old_leftovers1[256 * 5..],
+            &deferred[256 * 8..256 * 8 + 128 * self.params.k],
+            &old_leftovers1[256 * 4 + 128..],
         )?;
 
         // deferred y_old should be the same
         self.equal_unless_base_case(
             cs.namespace(|| "deferred[y_old] == old_leftovers1[y_old]"),
             base_case.clone(),
-            &deferred[256 * 1..256 * 2],
-            &old_leftovers1[256 * 2..256 * 3],
+            &deferred[128 * 1..128 * 2],
+            &old_leftovers1[256 * 2..256 * 2 + 128],
         )?;
 
         self.inner_circuit.synthesize(

--- a/src/recursion.rs
+++ b/src/recursion.rs
@@ -1301,9 +1301,9 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
         bits: &[AllocatedBit],
     ) -> Result<AllocatedNum<E1::Scalar>, SynthesisError> {
         assert_eq!(bits.len(), 128);
-        let mut acc = Combination::from(Num::constant(E1::Scalar::one()));
+        let mut acc = Combination::from(Num::constant(E1::Scalar::one() + &E1::Scalar::one() + &E1::Scalar::one()));
 
-        for i in 0..64 {
+        for i in 1..64 {
             let should_negate = &bits[i * 2];
             let should_endo = &bits[i * 2 + 1];
 

--- a/src/recursion.rs
+++ b/src/recursion.rs
@@ -1575,7 +1575,7 @@ impl<'a, E1: Curve, E2: Curve<Base = E1::Scalar>, Inner: RecursiveCircuit<E1::Sc
                     }
                 }
             } else {
-                let dummy_deferred = Deferred::<E2::Scalar>::dummy(self.params.k);
+                let dummy_deferred = Deferred::<E1::Scalar>::dummy(self.params.k);
                 let bytes = dummy_deferred.to_bytes();
                 for (_, byte) in bytes.into_iter().enumerate() {
                     for i in 0..8 {

--- a/src/rescue.rs
+++ b/src/rescue.rs
@@ -148,6 +148,7 @@ fn rescue_duplex<F: Field>(
     output
 }
 
+#[derive(Clone)]
 enum SpongeState<F: Field> {
     Absorbing([Option<F>; SPONGE_RATE]),
     Squeezing([Option<F>; SPONGE_RATE]),
@@ -161,6 +162,7 @@ impl<F: Field> SpongeState<F> {
     }
 }
 
+#[derive(Clone)]
 pub struct Rescue<F: Field> {
     sponge: SpongeState<F>,
     state: [F; RESCUE_M],

--- a/src/util.rs
+++ b/src/util.rs
@@ -348,6 +348,30 @@ fn test_fft() {
     assert_eq!(valid_product, naive_product);
 }
 
+pub fn get_challenge_scalar<F1: Field, F2: Field>(challenge: F1) -> F2 {
+    let challenge = challenge.get_lower_128();
+
+    let mut acc = F2::one();
+
+    for i in 0..64 {
+        let should_negate = (challenge >> (i * 2)) & 1 == 1;
+        let should_endo = (challenge >> (i * 2 + 1)) & 1 == 1;
+
+        acc = acc + &acc;
+        if should_negate {
+            acc = acc - &F2::one();
+        } else {
+            acc = acc + &F2::one();
+        }
+
+        if should_endo {
+            acc = acc * &F2::BETA;
+        }
+    }
+
+    acc
+}
+
 pub fn compute_b<F: Field>(x: F, challenges: &[F], challenges_inv: &[F]) -> F {
     assert!(!challenges.is_empty());
     assert_eq!(challenges.len(), challenges_inv.len());

--- a/src/util.rs
+++ b/src/util.rs
@@ -352,8 +352,10 @@ pub fn get_challenge_scalar<F1: Field, F2: Field>(challenge: F1) -> F2 {
     let challenge = challenge.get_lower_128();
 
     let mut acc = F2::one();
+    acc = acc + acc;
+    acc = acc + F2::one();
 
-    for i in 0..64 {
+    for i in 1..64 {
         let should_negate = (challenge >> (i * 2)) & 1 == 1;
         let should_endo = (challenge >> (i * 2 + 1)) & 1 == 1;
 


### PR DESCRIPTION
- [x] sample challenges as squares (sends n from 1667613 to 1223794)
- [x] send challenges as 128-bit over public inputs (sends n from 1223794 to 1104626)
- [x] use endomorphism to speed up inner product 128-bit multiplications (sends n from 1104626 to 901482)
- [x] reduce k to 22 (sends n from 901482 to 881984, proving time from 373.19s to 193.88s, verification time from 33.75s to 24.23s)
- [x] use endomorphism to speed up multiplications for z (sends n from 881984 to 876594)
- [x] multieq some comparisons (sends n from 876594 to 865535)
- [ ] (maybe) compute k(Y) commitment using Pedersen hashes
- [ ] (maybe) compute opening commitments using window table lookups
- [ ] (maybe) don't encode old challenges twice (once in deferred and once in leftovers)